### PR TITLE
fix: resolve Vitest TDZ on NiceNavigationItemRef initialization

### DIFF
--- a/src/ngx-navigation/navigation/navigation-item-ref.ts
+++ b/src/ngx-navigation/navigation/navigation-item-ref.ts
@@ -1,5 +1,5 @@
-import { Directive, inject, input, TemplateRef } from "@angular/core";
-import { NiceNavigation } from "./navigation";
+import { Directive, forwardRef, inject, input, TemplateRef } from "@angular/core";
+import { NiceNavigationItemsRenderer } from "./navigation-items";
 
 export type NiceNavigationItemRefContext = {
     $implicit: string;
@@ -16,7 +16,10 @@ export class NiceNavigationItemRef {
         return this.navigation?.ref ?? null;
     }
 
-    protected navigation: NiceNavigation | null = inject(NiceNavigation, { optional: true, skipSelf: true });
+    protected navigation: NiceNavigationItemsRenderer | null = inject(
+        forwardRef(() => NiceNavigationItemsRenderer),
+        { optional: true, skipSelf: true }
+    );
 
     constructor(public templateRef: TemplateRef<NiceNavigationItemRefContext>) {}
 }

--- a/src/ngx-navigation/navigation/navigation-items.ts
+++ b/src/ngx-navigation/navigation/navigation-items.ts
@@ -6,6 +6,7 @@ import {
     computed,
     contentChildren,
     Directive, effect,
+    forwardRef,
     inject,
     input,
     signal,
@@ -18,7 +19,10 @@ import { NavigationStore } from "./store";
 
 @Directive()
 export abstract class NiceNavigationItemsRenderer implements AfterContentInit {
-    protected readonly _contentItemRef = contentChildren(NiceNavigationItemRef, { descendants: true });
+    protected readonly _contentItemRef = contentChildren(
+        forwardRef(() => NiceNavigationItemRef),
+        { descendants: true }
+    );
 
     public items = computed(() => {
         const items = this.store.items();
@@ -30,7 +34,7 @@ export abstract class NiceNavigationItemsRenderer implements AfterContentInit {
         return items.filter((item) => item.startsWith(`${path}.`)).map((item) => item.replace(`${path}.`, ""));
     });
 
-    public ref: NiceNavigationItemRef | null = inject(NiceNavigationItemRef, { optional: true });
+    public ref: NiceNavigationItemRef | null = inject(forwardRef(() => NiceNavigationItemRef), { optional: true });
     public contentItemRefByName = new Map<string, NiceNavigationItemRef>();
     public _navigationOutlet: NiceNavigationOutlet | null = null;
     private _hasInitialized = false;


### PR DESCRIPTION
## Summary

Fixes a `ReferenceError: Cannot access 'NiceNavigationItemRef' before initialization` occurring under **Vitest** when a consumer project loads the package TypeScript sources through sourcemaps. `ng serve` / `ng build` were not impacted.

## Problem

Two combined causes in the navigation module graph:

**1. TDZ in `NiceNavigationItemsRenderer`**

Signal field initializers access `NiceNavigationItemRef` during class evaluation:

```ts
contentChildren(NiceNavigationItemRef, …)
inject(NiceNavigationItemRef, …)
```

Angular metadata already used `forwardRef`, but the compiled field initializers did not.

**2. Runtime import cycle**

```txt
navigation-items.ts → navigation-item-ref.ts → navigation.ts → navigation-items.ts
```

## Changes

### `navigation-items.ts`

- Added `forwardRef` to `contentChildren` and `inject`.

### `navigation-item-ref.ts`

- Replaced the `NiceNavigation` runtime import with `NiceNavigationItemsRenderer`.
- Added `forwardRef` to `inject` to break the runtime cycle down to 3 files.

## Impact

- No public API changes.
- No regression on `ng serve` / `ng build`.

Note:

This bug is not reproducible through `ng test` inside the library itself because `@angular/build:unit-test` bundles all sources into a single Vite chunk, masking the ESM initialization-order issue.