### PR TITLE
fix: match strict de routerLinkActive via l'input exact

### DIFF
--- a/src/ngx-navigation/navigation/basic/item-basic.template.html
+++ b/src/ngx-navigation/navigation/basic/item-basic.template.html
@@ -1,4 +1,9 @@
-<div class="nice-navigation-basic-item" [routerLink]="link()" routerLinkActive="item-active">
+<div
+    class="nice-navigation-basic-item"
+    [routerLink]="link()"
+    routerLinkActive="item-active"
+    [routerLinkActiveOptions]="routerLinkActiveOptions()"
+>
     <div class="nice-navigation-item-icon-container">
         <ng-content select="[itemIcon]"></ng-content>
     </div>

--- a/src/ngx-navigation/navigation/navigation-items.spec.ts
+++ b/src/ngx-navigation/navigation/navigation-items.spec.ts
@@ -1,0 +1,71 @@
+import { Component } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { provideRouter } from "@angular/router";
+import { RouterTestingHarness } from "@angular/router/testing";
+import { NiceBasicNavigationItems } from "./navigation-items";
+
+@Component({
+    template: `
+        <nice-basic-navigation link="/dashboard" [exact]="exact">
+            <span itemTitle>Dashboard</span>
+        </nice-basic-navigation>
+    `,
+    imports: [NiceBasicNavigationItems]
+})
+class TestHostComponent {
+    public exact = false;
+}
+
+describe("NiceBasicNavigationItems", () => {
+    let fixture: ComponentFixture<TestHostComponent>;
+    let harness: RouterTestingHarness;
+    let host: TestHostComponent;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [TestHostComponent],
+            providers: [
+                provideRouter([
+                    { path: "dashboard", component: TestHostComponent },
+                    { path: "dashboard/users", component: TestHostComponent }
+                ])
+            ]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestHostComponent);
+        host = fixture.componentInstance;
+        harness = await RouterTestingHarness.create();
+        fixture.detectChanges();
+    });
+
+    function getNavigationItem(): HTMLElement {
+        return fixture.nativeElement.querySelector(".nice-navigation-basic-item");
+    }
+
+    it("marks the item active on a child route by default", async () => {
+        await harness.navigateByUrl("/dashboard/users");
+        fixture.detectChanges();
+
+        expect(getNavigationItem().classList.contains("item-active")).toBe(true);
+    });
+
+    it("marks the item inactive on a child route when exact is true", async () => {
+        host.exact = true;
+        fixture.detectChanges();
+
+        await harness.navigateByUrl("/dashboard/users");
+        fixture.detectChanges();
+
+        expect(getNavigationItem().classList.contains("item-active")).toBe(false);
+    });
+
+    it("marks the item active on the exact route when exact is true", async () => {
+        host.exact = true;
+        fixture.detectChanges();
+
+        await harness.navigateByUrl("/dashboard");
+        fixture.detectChanges();
+
+        expect(getNavigationItem().classList.contains("item-active")).toBe(true);
+    });
+});

--- a/src/ngx-navigation/navigation/navigation-items.ts
+++ b/src/ngx-navigation/navigation/navigation-items.ts
@@ -121,6 +121,9 @@ export abstract class NiceNavigationItemsRenderer implements AfterContentInit {
 })
 export class NiceBasicNavigationItems {
     public link = input.required<string>();
+    public readonly exact = input(false, { transform: booleanAttribute });
+
+    protected readonly routerLinkActiveOptions = computed(() => ({ exact: this.exact() }));
 }
 
 @Directive({


### PR DESCRIPTION
## Résumé

- Ajoute un input optionnel `exact` (défaut `false`) sur `nice-basic-navigation` (`NiceBasicNavigationItems`).
- Branche `exact` sur `[routerLinkActiveOptions]="{ exact: true }"` dans le template.
- Ajoute des tests unitaires couvrant le comportement avec et sans `exact`.

## Problème

Par défaut, `RouterLinkActive` considère un lien comme actif lorsque l'URL courante **correspond au lien ou à une sous-route** (match par préfixe). Sur une navigation avec un item parent `/dashboard` et un enfant `/dashboard/users`, les deux items sont surlignés en même temps sur `/dashboard/users`.

## Solution

Avec `[exact]="true"`, le lien n'est actif **que** sur l'URL exacte :

```html
<nice-basic-navigation *niceNavigationItemRef="'home'" link="/dashboard" [exact]="true">
```

Les autres items n'ont pas besoin de changer (`exact` reste `false` par défaut).
